### PR TITLE
godb/mongo: set dial timeout when connecting to test database

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -1,6 +1,9 @@
 package mongo
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/clouway/godb"
 	"gopkg.in/mgo.v2"
 )
@@ -13,11 +16,11 @@ type database struct {
 // NewDatabase establishes a new database connection using
 // configuration options in the provided config.
 func NewDatabase(config *godb.Config) godb.Database {
-	info := &mgo.DialInfo{Addrs: config.Addrs}
+	info := &mgo.DialInfo{Addrs: config.Addrs, Timeout: 5 * time.Second}
 	sess, err := mgo.DialWithInfo(info)
 
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("unable to connect to host '%s', failed with: %v", info.Addrs, err))
 	}
 
 	db := sess.DB(config.Database)


### PR DESCRIPTION
Added a small timeout of 5 seconds for Dialing to prevent long hangs during testing.

```
panic: unable to connect to reachable database '[localhost:27017]': no
reachable servers

goroutine 1 [running]:
panic(0x29e400, 0xc420122250)

```