### PR TITLE
godb/mongo: retry attempts and return error as result

### DIFF
--- a/datastoretest/mongo.go
+++ b/datastoretest/mongo.go
@@ -39,7 +39,10 @@ func NewDatabaseWithHost(host string) *DB {
 		Database: name,
 	}
 
-	mgoDB := mongo.NewDatabase(config)
+	mgoDB, err := mongo.NewDatabase(config)
+	if err != nil {
+		panic(fmt.Errorf("could not establish connection: %v", err))
+	}
 
 	sess, err := connect(host)
 	if err != nil {

--- a/godb.go
+++ b/godb.go
@@ -54,10 +54,14 @@ type Bulk interface {
 	Update(pairs ...interface{})
 }
 
+// Config is a configuration object used for the communication with
+// the database
 type Config struct {
-	Addrs []string
+	Addrs []string // slice of hosts
 
-	Database string
+	Database string // name of the database
+
+	MaxRetryAttempts int // number of max retry attempts
 }
 
 type Change struct {


### PR DESCRIPTION
The design for the mongodb database is changed to retry until MaxRetryAttempts config option is reached.

If DB is not available even after all attempts then an error response is returned.

This change will cause compilation on old client, cause signature of the func is changed from: 

```go
db := mongo.NewDatabase(config)
```
to
```go
db, err := mongo.NewDatabase(config)
```