### PR TITLE
godb: clean database before close connection

### DIFF
--- a/datastoretest/mongo.go
+++ b/datastoretest/mongo.go
@@ -60,6 +60,7 @@ func NewDatabaseWithHost(host string) *DB {
 
 // Close closes DB connection
 func (db *DB) Close() {
+	db.Clean()
 	db.database.Session.Close()
 }
 


### PR DESCRIPTION
We clean database before close connection, because in tests where we use god we should add one line ```db.Clean()```
```go
func TestMain(m *testing.M) {
	db = datastoretest.NewDatabase()

	code := m.Run()
        db.Clien()
	db.Close()
	os.Exit(code)
}
```  

Now when we update godb in vendor directory in projects we will not change anything. 