### PR TITLE
godb: add indexing support

### DIFF
--- a/godb.go
+++ b/godb.go
@@ -1,11 +1,19 @@
 package godb
 
+// Database is reprsenting the database
 type Database interface {
+	// Close closes the connection to the database
 	Close()
 
+	// Collection is getting collection by it's name
 	Collection(name string) Collection
+
+	// Gets Indexer for the provided collection name
+	Indexer(cname string) Indexer
 }
 
+// Collection is a collection in the database. Single database is having
+// multiple collections and this interface is representing one of them.
 type Collection interface {
 	Find(query interface{}) Query
 
@@ -24,6 +32,12 @@ type Collection interface {
 	RemoveAll(selector interface{}) (*ChangeInfo, error)
 
 	Bulk() Bulk
+}
+
+// Indexer is responsible for creation of indexes
+type Indexer interface {
+	// CreateAll creates all provided indexes
+	CreateAll([]Index) error
 }
 
 type Query interface {
@@ -77,7 +91,20 @@ type ChangeInfo struct {
 	UpsertedID interface{}
 }
 
+// BulkResult is a result of the Bulk operation. It indicates
+// how many records are affected
 type BulkResult struct {
 	Matched  int
 	Modified int
+}
+
+// Index is representing a single index in the datastore
+type Index struct {
+	// The key which to participates in the index. It's a slice
+	// to support and composite indexes
+	Key []string
+
+	// Unique is flag which indicates whether index should
+	// be unique or not
+	Unique bool
 }


### PR DESCRIPTION
Some apps need to be add indexes to perform faster query operations. This change adds Indexes to the godb API to provide such functionality.