### PR TITLE
godb: implement AllowDiskUse for the pipe

### DIFF
--- a/datastoretest/fake.go
+++ b/datastoretest/fake.go
@@ -185,6 +185,11 @@ type FakePipe struct {
 	mock.Mock
 }
 
+func (b *FakePipe) AllowDiskUse() godb.Pipe {
+	b.Called()
+	return b
+}
+
 func (b *FakePipe) Iter() godb.Iter {
 	return b.FakeIter
 }

--- a/godb.go
+++ b/godb.go
@@ -107,6 +107,8 @@ type Pipe interface {
 	One(result interface{}) error
 
 	Iter() Iter
+
+	AllowDiskUse() Pipe
 }
 
 // Config is a configuration object used for the communication with

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -381,12 +381,17 @@ func (p *pipe) Iter() godb.Iter {
 	}
 }
 
+func (p *pipe) AllowDiskUse() *pipe {
+	p.pipe.AllowDiskUse()
+	return p
+}
+
 func adaptChangeInfo(info *mgo.ChangeInfo) *godb.ChangeInfo {
 	if info == nil {
 		return nil
 	}
 
-	return &godb.ChangeInfo{Updated: info.Updated, Removed: info.Removed, Matched:info.Matched, UpsertedID: info.UpsertedId}
+	return &godb.ChangeInfo{Updated: info.Updated, Removed: info.Removed, Matched: info.Matched, UpsertedID: info.UpsertedId}
 }
 
 func adaptBulkResult(r *mgo.BulkResult) *godb.BulkResult {


### PR DESCRIPTION
If pipe is used with a sort on a large collection it could exceed the 100mb memory limit of mongo. So we must manually enable the AllowDiskUse for mongo versions bellow 6.X.